### PR TITLE
Corrections sur les slides

### DIFF
--- a/slides/afl.tex
+++ b/slides/afl.tex
@@ -130,7 +130,7 @@
           \item \lstinline{fork()} pour copier le processus
           \item \lstinline{waitpid()} pour surveiller les enfants
           \end{itemize}
-        \item communication entre alf-fuzz et programme parent avec un \lstinline{pipe}
+        \item communication entre \lstinline{afl-fuzz} et programme parent avec un \lstinline{pipe}
         \end{itemize}
       \end{block}
     \end{column}

--- a/slides/binaires_quelconques_et_autres_plateformes.tex
+++ b/slides/binaires_quelconques_et_autres_plateformes.tex
@@ -71,10 +71,9 @@
   \end{block}
 
   \begin{exampleblock}{WinAFL (ProjectZero)}
-	  \begin{itemize}
-	  \item \sout{instrumentation}, \sout{fork server}
+    \begin{itemize}
+    \item \sout{instrumentation}, \sout{fork server}
     \item instrumentation dynamique avec \lstinline{DynamoRIO}
-    \item mode persistent
-	  \end{itemize}
+    \end{itemize}
   \end{exampleblock}
 \end{frame}


### PR DESCRIPTION
  * ne pas mentionner `persistent mode` pour WinAFL
  * typo et style pour `afl-fuzz`
  * indentation